### PR TITLE
Correct package.json entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "express-multer-mock-storage",
   "version": "0.0.1",
   "description": "By using this throttled dummy storage you can slow down a file uploading to debug the ajax thing.",
-  "main": "src/index.js",
+  "main": "src/storage.js",
   "author": "ladjzero@gmail.com",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
Importing 'express-multer-mock-storage' faisl with "Cannot find module '<repository>/node_modules/express-multer-mock-storage/src/index.js'. Please verify that the package.json has a valid "main" entry" because there is no index.js in the src folder.